### PR TITLE
silhouette edge fix

### DIFF
--- a/motion_blur/moblur_shader.shader
+++ b/motion_blur/moblur_shader.shader
@@ -36,7 +36,7 @@ void fragment()
 	for (int i = 0; i < iteration_count; i++)
 	{
 		vec2 offset = pixel_diff_ndc * (float(i) / float(iteration_count) - 0.5) * intensity; 
-		col += texture(SCREEN_TEXTURE, SCREEN_UV + offset).rgb;
+		col += textureLod(SCREEN_TEXTURE, SCREEN_UV + offset,0.0).rgb;
 		counter++;
 	}
 	ALBEDO = col / counter;


### PR DESCRIPTION
hi, 
i thought i`d help you a bit on this.
what I did was to set mip-mapping to 0.0 by "textureLod(sampler, coord, lod)" function. 
This would not be necessary for Godot`s "screen_shaders", but you need to force it whenever you use "spatial_shader" as a screen shader.

cheers,
martinsh